### PR TITLE
JCLOUDS-1262: Add the Ohio region to AWS

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/domain/Region.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/domain/Region.java
@@ -66,9 +66,14 @@ public class Region {
    public static final String US_STANDARD = "us-standard";
 
    /**
-    * 
+    * US-East-1 (N. Virginia)
     */
    public static final String US_EAST_1 = "us-east-1";
+
+   /**
+    * US-East-2 (Ohio)
+    */
+    public static final String US_EAST_2 = "us-east-2";
 
    /**
     * US-West (Northern California) <h3>S3</h3> Uses Amazon S3 servers in Northern California
@@ -121,10 +126,10 @@ public class Region {
     */
    public static final String AP_NORTHEAST_2 = "ap-northeast-2";
 
-   public static final Set<String> DEFAULT_S3 = ImmutableSet.of(US_STANDARD, US_WEST_1, US_WEST_2, EU_WEST_1, EU_CENTRAL_1, SA_EAST_1,
+   public static final Set<String> DEFAULT_S3 = ImmutableSet.of(US_STANDARD, US_EAST_2, US_WEST_1, US_WEST_2, EU_WEST_1, EU_CENTRAL_1, SA_EAST_1,
          AP_SOUTHEAST_1, AP_SOUTHEAST_2, AP_SOUTH_1, AP_NORTHEAST_1, AP_NORTHEAST_2);
 
-   public static final Set<String> DEFAULT_REGIONS = ImmutableSet.of(US_EAST_1, US_WEST_1, US_WEST_2, SA_EAST_1,
+   public static final Set<String> DEFAULT_REGIONS = ImmutableSet.of(US_EAST_1, US_EAST_2, US_WEST_1, US_WEST_2, SA_EAST_1,
          EU_WEST_1, EU_CENTRAL_1, AP_SOUTHEAST_1, AP_SOUTHEAST_2, AP_SOUTH_1, AP_NORTHEAST_1, AP_NORTHEAST_2);
 
    public static Properties regionPropertiesS3() {
@@ -132,7 +137,7 @@ public class Region {
       Properties properties = regionProperties();
       properties.setProperty(PROPERTY_REGIONS, Joiner.on(',').join(DEFAULT_S3));
       // note that due to US_STANDARD the codes include US instead of US-VA
-      properties.setProperty(PROPERTY_ISO3166_CODES, "US,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
+      properties.setProperty(PROPERTY_ISO3166_CODES, "US,US_OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
       properties.setProperty(PROPERTY_REGION + "." + US_STANDARD + "." + ISO3166_CODES, "US");
       return properties;
    }
@@ -140,8 +145,9 @@ public class Region {
    public static Properties regionProperties() {
       Properties properties = new Properties();
       properties.setProperty(PROPERTY_REGIONS, Joiner.on(',').join(DEFAULT_REGIONS));
-      properties.setProperty(PROPERTY_ISO3166_CODES, "US-VA,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
+      properties.setProperty(PROPERTY_ISO3166_CODES, "US-VA,US_OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
       properties.setProperty(PROPERTY_REGION + "." + US_EAST_1 + "." + ISO3166_CODES, "US-VA");
+      properties.setProperty(PROPERTY_REGION + "." + US_EAST_2 + "." + ISO3166_CODES, "US-OH");
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_1 + "." + ISO3166_CODES, "US-CA");
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_2 + "." + ISO3166_CODES, "US-OR");
       properties.setProperty(PROPERTY_REGION + "." + SA_EAST_1 + "." + ISO3166_CODES, "BR-SP");

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
@@ -86,7 +86,7 @@ public class AWSEC2ProviderMetadata extends BaseProviderMetadata {
          .console(URI.create("https://console.aws.amazon.com/ec2/home"))
          .defaultProperties(AWSEC2ProviderMetadata.defaultProperties())
          .linkedServices("aws-ec2", "aws-elb", "aws-cloudwatch", "aws-s3", "aws-simpledb")
-         .iso3166Codes("US-VA", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
+         .iso3166Codes("US-VA", "US_OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
       }
 
       @Override

--- a/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
+++ b/providers/aws-ec2/src/test/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateBuilderLiveTest.java
@@ -353,7 +353,7 @@ public class AWSEC2TemplateBuilderLiveTest extends EC2TemplateBuilderLiveTest {
 
    @Override
    protected Set<String> getIso3166Codes() {
-      return ImmutableSet.of("US-VA", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
+      return ImmutableSet.of("US-VA", "US-OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
    }
 
 }

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
@@ -25,6 +25,7 @@ import static org.jclouds.aws.domain.Region.AP_SOUTH_1;
 import static org.jclouds.aws.domain.Region.EU_CENTRAL_1;
 import static org.jclouds.aws.domain.Region.EU_WEST_1;
 import static org.jclouds.aws.domain.Region.SA_EAST_1;
+import static org.jclouds.aws.domain.Region.US_EAST_2;
 import static org.jclouds.aws.domain.Region.US_STANDARD;
 import static org.jclouds.aws.domain.Region.US_WEST_1;
 import static org.jclouds.aws.domain.Region.US_WEST_2;
@@ -69,6 +70,7 @@ public class AWSS3ProviderMetadata extends BaseProviderMetadata {
       properties.putAll(Region.regionPropertiesS3());
       properties.setProperty(PROPERTY_ENDPOINT, "https://s3.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + US_STANDARD + "." + ENDPOINT, "https://s3.amazonaws.com");
+      properties.setProperty(PROPERTY_REGION + "." + US_EAST_2 + "." + ENDPOINT, "https://s3-us-east-2.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_1 + "." + ENDPOINT, "https://s3-us-west-1.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_2 + "." + ENDPOINT, "https://s3-us-west-2.amazonaws.com");
       properties.setProperty(PROPERTY_REGION + "." + SA_EAST_1 + "." + ENDPOINT, "https://s3-sa-east-1.amazonaws.com");
@@ -97,7 +99,7 @@ public class AWSS3ProviderMetadata extends BaseProviderMetadata {
          .homepage(URI.create("http://aws.amazon.com/s3"))
          .console(URI.create("https://console.aws.amazon.com/s3/home"))
          .linkedServices("aws-ec2", "aws-elb", "aws-cloudwatch", "aws-s3", "aws-simpledb")
-         .iso3166Codes("US", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11")
+         .iso3166Codes("US", "US_OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11")
          .defaultProperties(AWSS3ProviderMetadata.defaultProperties());
       }
 

--- a/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/integration/AWSS3ServiceIntegrationLiveTest.java
+++ b/providers/aws-s3/src/test/java/org/jclouds/aws/s3/blobstore/integration/AWSS3ServiceIntegrationLiveTest.java
@@ -43,6 +43,7 @@ public class AWSS3ServiceIntegrationLiveTest extends S3ServiceIntegrationLiveTes
             "SG",
             "US",
             "US-CA",
+            "US-OH",
             "US-OR");
    }
 


### PR DESCRIPTION
This is a manual cherry-pick conflict resolution from master patch
04ab255 on jclouds master to build jclouds 2.0.2-beta.2. The major
change was to exclude China, Canada and London regions from this
build because they were not on track for this release.