### PR TITLE
JCLOUDS-1262: Correct US-OH region

### DIFF
--- a/apis/sts/src/main/java/org/jclouds/aws/domain/Region.java
+++ b/apis/sts/src/main/java/org/jclouds/aws/domain/Region.java
@@ -137,7 +137,7 @@ public class Region {
       Properties properties = regionProperties();
       properties.setProperty(PROPERTY_REGIONS, Joiner.on(',').join(DEFAULT_S3));
       // note that due to US_STANDARD the codes include US instead of US-VA
-      properties.setProperty(PROPERTY_ISO3166_CODES, "US,US_OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
+      properties.setProperty(PROPERTY_ISO3166_CODES, "US,US-OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
       properties.setProperty(PROPERTY_REGION + "." + US_STANDARD + "." + ISO3166_CODES, "US");
       return properties;
    }
@@ -145,7 +145,7 @@ public class Region {
    public static Properties regionProperties() {
       Properties properties = new Properties();
       properties.setProperty(PROPERTY_REGIONS, Joiner.on(',').join(DEFAULT_REGIONS));
-      properties.setProperty(PROPERTY_ISO3166_CODES, "US-VA,US_OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
+      properties.setProperty(PROPERTY_ISO3166_CODES, "US-VA,US-OH,US-CA,US-OR,BR-SP,IE,DE-HE,SG,AU-NSW,IN-MH,JP-13,KR-11");
       properties.setProperty(PROPERTY_REGION + "." + US_EAST_1 + "." + ISO3166_CODES, "US-VA");
       properties.setProperty(PROPERTY_REGION + "." + US_EAST_2 + "." + ISO3166_CODES, "US-OH");
       properties.setProperty(PROPERTY_REGION + "." + US_WEST_1 + "." + ISO3166_CODES, "US-CA");

--- a/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
+++ b/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/AWSEC2ProviderMetadata.java
@@ -86,7 +86,7 @@ public class AWSEC2ProviderMetadata extends BaseProviderMetadata {
          .console(URI.create("https://console.aws.amazon.com/ec2/home"))
          .defaultProperties(AWSEC2ProviderMetadata.defaultProperties())
          .linkedServices("aws-ec2", "aws-elb", "aws-cloudwatch", "aws-s3", "aws-simpledb")
-         .iso3166Codes("US-VA", "US_OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
+         .iso3166Codes("US-VA", "US-OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11");
       }
 
       @Override

--- a/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
+++ b/providers/aws-s3/src/main/java/org/jclouds/aws/s3/AWSS3ProviderMetadata.java
@@ -99,7 +99,7 @@ public class AWSS3ProviderMetadata extends BaseProviderMetadata {
          .homepage(URI.create("http://aws.amazon.com/s3"))
          .console(URI.create("https://console.aws.amazon.com/s3/home"))
          .linkedServices("aws-ec2", "aws-elb", "aws-cloudwatch", "aws-s3", "aws-simpledb")
-         .iso3166Codes("US", "US_OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11")
+         .iso3166Codes("US", "US-OH", "US-CA", "US-OR", "BR-SP", "IE", "DE-HE", "SG", "AU-NSW", "IN-MH", "JP-13", "KR-11")
          .defaultProperties(AWSS3ProviderMetadata.defaultProperties());
       }
 


### PR DESCRIPTION
This is a manual cherry-pick conflict resolution from jclouds
master patch 5a1c955. Since we did not include London, China and
Canada in the previous patch, conflicts had to be resolved manually.