### PR TITLE
Get rid of SLO removeBlob

### DIFF
--- a/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
+++ b/apis/openstack-swift/src/main/java/org/jclouds/openstack/swift/v1/blobstore/RegionScopedSwiftBlobStore.java
@@ -386,14 +386,8 @@ public class RegionScopedSwiftBlobStore implements BlobStore {
 
    @Override
    public void removeBlob(String container, String name) {
-      // Multipart objects have a manifest which points to subobjects.  Normally
-      // deleting a object only deletes the manifest, leaving the subobjects.
-      // We first try a multipart delete and if that fails since the object is
-      // not an MPU we fall back to single-part delete.
-      DeleteStaticLargeObjectResponse response = api.getStaticLargeObjectApi(regionId, container).delete(name);
-      if (!response.status().equals("200 OK")) {
-         api.getObjectApi(regionId, container).delete(name);
-      }
+      // Use single-part delete instead of SLO delete because its buggy(NPE).
+      api.getObjectApi(regionId, container).delete(name);
    }
 
    /**


### PR DESCRIPTION
SITECACHE-577, SITECACHE-587, CLOUD-2957
JCLOUDS-1240, JCLOUDS-1281, JCLOUDS-1251

Jclouds throws NPE while processing Static Large Object (SLO)
DELETE request. Until its fixed, this patch temporarily avoids SLO
support for DELETE requests.
Internally, SiteCache never needs SLO support, because a single blob
can never grow as large as large-object's range of giga bytes.